### PR TITLE
Updated syntax for Swift 3.0

### DIFF
--- a/GuardedSwiftyJSON.xcodeproj/project.pbxproj
+++ b/GuardedSwiftyJSON.xcodeproj/project.pbxproj
@@ -199,9 +199,11 @@
 				TargetAttributes = {
 					55FE27151D4ADF5B008C5C67 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0820;
 					};
 					55FE271F1D4ADF5B008C5C67 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};
@@ -410,6 +412,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -431,6 +434,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = au.com.thoughtworks.GuardedSwiftyJSON;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -448,6 +452,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "GuardedSwiftyJsonTests/GuardedSwiftyJsonTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -464,6 +469,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = au.com.thoughtworks.GuardedSwiftyJsonTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "GuardedSwiftyJsonTests/GuardedSwiftyJsonTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/GuardedSwiftyJSON/GuardedSwiftyJson.swift
+++ b/GuardedSwiftyJSON/GuardedSwiftyJson.swift
@@ -90,7 +90,7 @@ private class GuardedJSONContext {
         closed = true
     }
 
-    func proxy(json: JSON) -> GuardedJSON {
+    func proxy(_ json: JSON) -> GuardedJSON {
         return _GuardedJSON(json: json, context: self)
     }
 }
@@ -98,7 +98,7 @@ private class GuardedJSONContext {
 class FatalErrorWrapper {
     static var sharedInstance = FatalErrorWrapper()
 
-    func fail(message: String) {
+    func fail(_ message: String) {
         fatalError(message)
     }
 }
@@ -245,7 +245,7 @@ private class _GuardedJSON : GuardedJSON {
         return context.proxy(rawJson[path])
     }
 
-    private func extractOrAbort<T : DefaultInitializable>(value: T?) -> T {
+    fileprivate func extractOrAbort<T : DefaultInitializable>(_ value: T?) -> T {
         if let value = value {
             return value
         } else {

--- a/GuardedSwiftyJsonTests/GuardedSwiftyJsonSpec.swift
+++ b/GuardedSwiftyJsonTests/GuardedSwiftyJsonSpec.swift
@@ -60,7 +60,7 @@ struct NestedStructFlattened : JsonInitializable {
 class FatalErrorStub : FatalErrorWrapper {
     var message : String?
 
-    override func fail(message: String) {
+    override func fail(_ message: String) {
         self.message = message
     }
 }


### PR DESCRIPTION
I simply used Xcode's swift converter for this.  The xcproject file seemed to have already been missing Quick and other things necessary to compile.  I did not attempt to fix those.  But the code-changes appear to be correct.